### PR TITLE
Fix `pum#visible()` result is not typeof number

### DIFF
--- a/denops/@ddc-uis/pum.ts
+++ b/denops/@ddc-uis/pum.ts
@@ -71,7 +71,7 @@ export class Ui extends BaseUi<Params> {
   override async visible(args: {
     denops: Denops;
   }): Promise<boolean> {
-    return await args.denops.call("pum#visible") !== 0;
+    return Boolean(await args.denops.call("pum#visible"));
   }
 
   override params(): Params {


### PR DESCRIPTION
Currently `visible()` always returned true because `pum#visible()` returns bool.
https://github.com/Shougo/pum.vim/blob/1f64d50bdaa5e3a92b7a57f88b61eb42ab4d3518/autoload/pum.vim#L192
Fix to use `Boolean` to convert.